### PR TITLE
Update 063-mapping-rf.Rmd

### DIFF
--- a/063-mapping-rf.Rmd
+++ b/063-mapping-rf.Rmd
@@ -238,7 +238,7 @@ summary(validation)
 ```{r, eval=TRUE, fig.cap='OCSKGM prediction based on 75% of data', echo=TRUE}
 # Plot of the map based on 75% of data and the sensitivity to data 
 # variations
-prediction75 <- exp(pred[[1]])
+prediction75 <- pred[[1]] #pred has already been back-transformed on line 174 above
 
 plot(prediction75, main='OCSKGM prediction based on 75% of data', 
      col=rev(topo.colors(10)))


### PR DESCRIPTION
Hi, kindly see line 241 where pred variable is being back-transformed with the exp function. 

I see that on line 174 above, you applied the back-transformation to the pred variable and it is the same pred variable being referenced on line 241 which makes the back-transformation redundant on line 241 (in my opinion...Please correct me if I am wrong). 

I think the exp function should be removed from line 241. Also, when exp is applied on line 241, the pred values for OCSKGM go out of the range of the original values.